### PR TITLE
Removing stray code fence

### DIFF
--- a/README.md
+++ b/README.md
@@ -52,7 +52,7 @@ A flag used to specify if the task should output information about the files it 
 ### Usage Examples
 
 Coming soon
-```
+
 
 ## Contributing
 In lieu of a formal styleguide, take care to maintain the existing coding style. Add unit tests for any new or changed functionality. Lint and test your code using [Grunt](http://gruntjs.com/).


### PR DESCRIPTION
... It was causing the "Contributing" and "Release History" sections to be rendered as a code block.
